### PR TITLE
Traducciones sleepy

### DIFF
--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -1,7 +1,7 @@
 /datum/perk/fate/paper_worm
-	name = "Paper Worm"
-	desc = "You were a clerk and bureaucrat for all your life. Cramped offices with angry people is where your personality was forged. \
-			You have lower stats all around, but have a higher chance to have increased stat growth on level up."
+	name = "Burocrático"
+	desc = "Siempre fuiste un empleado y un burocrata toda tu vida. Oficinas apretadas con personas enojadas es donde tu personalidad fue forjada. \
+			Tienes stats mas bajas en todo, pero tienes una mayor chance de conseguir aumentos de stats extra cuando subis de nivel."
 	icon_state = "paper"
 
 /datum/perk/fate/paper_worm/assign(mob/living/carbon/human/H)
@@ -15,10 +15,10 @@
 	..()
 
 /datum/perk/fate/freelancer
-	name = "Freelancer"
+	name = "Independiente"
 	icon_state = "skills"
-	desc = "Whatever was your job, you never stayed in one place for too long or had lasting contracts. \
-			This perk checks your highest stat, lowers it by 10 and improves all others by 4."
+	desc = "Cualquier sea tu trabajo, nunca pudieste estar en un lugar por mucho tiempo o tuviste contactos duraderos. \
+			este perk checkea tu mayor stat, lo baja por 10 puntos y mejora toda las otras por 4 puntos."
 
 /datum/perk/fate/freelancer/assign(mob/living/carbon/human/H)
 	..()
@@ -36,10 +36,10 @@
 				holder.stats.changeStat(name, -10)
 
 /datum/perk/fate/nihilist
-	name = "Nihilist"
-	desc = 	"You simply ran out of fucks to give at some point in your life. \
-			This increases chance of positive breakdowns by 10% and negative breakdowns by 20%. Seeing someone die has a random effect on you: \
-			sometimes you won’t take any sanity loss and you can even gain back sanity, or get a boost to your cognition."
+	name = "Nihilista"
+	desc = 	"En algun punto de tu vida te rendiste en que te importara esta. \
+			Esto incrementa tu chance de ataques de panicos positivos por un 10% y los negativos por un 20%. Ver a alguien morir tiene un efecto aleatorio en ti: \
+			algunas veces no tendras ninguna perdida de salud mental y quizas ganes sanidad, o consigas un boost a tu cognicion."
 	icon_state = "eye" //https://game-icons.net/1x1/lorc/tear-tracks.html
 
 /datum/perk/fate/nihilist/assign(mob/living/carbon/human/H)
@@ -56,18 +56,18 @@
 	..()
 
 /datum/perk/fate/moralist
-	name = "Moralist"
+	name = "Moralista"
 	icon_state = "moralist" //https://game-icons.net/
-	desc = "A day may come when the courage of men fails, when we forsake our friends and break all bonds of fellowship. \
-			But it is not this day. This day you fight! \
-			Your Insight gain is faster when you are around sane people and they will recover sanity when around you. \
-			When you are around people that are low on health or sanity, you will take sanity damage."
+	desc = "Un dia llegara donde el coraje de los hombres caera, cuando abandonemos a nuestros amigos y rompamos todo los lazos de compañerismo. \
+			Pero este no es ese dia. Este sera el dia donde lucharas! \
+			Ganas conocimiento mas rapido cuando estas rodeado de gente sana y ellos recuperaran sanidad si estan cerca de ti. \
+			Cuando estas cerca de personas que estan con salud mental baja, empezaras a tomar daño a tu propia sanidad."
 
 /datum/perk/fate/drug_addict
-	name = "Drug Addict"
+	name = "Adicto a las drogas"
 	icon_state = "medicine" //https://game-icons.net/1x1/delapouite/medicines.html
-	desc = "For reasons you cannot remember, you decided to resort to major drug use. You have lost the battle, and now you suffer the consequences. \
-			You start with an addiction to a random drug, as well as a bottle of pills containing the drug."
+	desc = "Por razones que no puedes recordar, decidiste recurrir al uso de drogas. Ahora perdiste la batalla y sufres las consecuencias. \
+			Empiezas con una adiccion a una droga aleatoria, ademas de una botella de pildoras que contienen tal droga."
 
 /datum/perk/fate/drug_addict/assign(mob/living/carbon/human/H)
 	..()
@@ -88,10 +88,10 @@
 				holder.equip_to_storage_or_drop(PB)
 
 /datum/perk/fate/alcoholic
-	name = "Alcoholic"
+	name = "Alcoholico"
 	icon_state = "beer" //https://game-icons.net/1x1/delapouite/beer-bottle.html
-	desc = "You imagined the egress from all your trouble and pain at the bottom of the bottle, but the way only led to a labyrinth. \
-			You have an alcohol addiction, which gives you a boost to robustness while under the influence and lowers your cognition permanently."
+	desc = "Siempre imaginaste que la salida de todos tus problemas y dolores se encontraba al fondo de la botella, pero ese camino solo te dirigio a un laberinto. \
+			Tienes una adiccion al alcohol, cosa que te da un boost a tu robustez mientras estes bajo la influencia pero te baja la cognicion permanentemente."
 
 /datum/perk/fate/alcoholic/assign(mob/living/carbon/human/H)
 	..()
@@ -121,8 +121,8 @@
 /datum/perk/fate/noble
 	name = "Noble"
 	icon_state = "family" //https://game-icons.net
-	desc = "You are a descendant of a long-lasting family, bearing a name of high status that can be traced back to the early civilization of your domain. \
-			Start with an heirloom weapon, higher chance to be on traitor contracts and removed sanity cap. Stay clear of filth and danger."
+	desc = "Eres el decendiente de una gran y prospera familia, llevando un nombre de gran status que puede se trasar hasta las civilizaciones mas jovenes de tu dominio. \
+			Empiezas con un arma reliquia, mayor chance de ser marcado como objetivo de traidores y tu cap de perdida de sanidad es removida. Mantente alejado del peligro y la suciedad."
 
 /datum/perk/fate/noble/assign(mob/living/carbon/human/H)
 	..()
@@ -141,7 +141,7 @@
 				/obj/item/weapon/gun/projectile/revolver = 0.4))
 	holder.sanity.valid_inspirations += W
 	W = new W(T)
-	W.desc += " It has been inscribed with the \"[holder.family_name]\" family name."
+	W.desc += " Esta inscrito con el nombre de tu familia \"[holder.family_name]\"."
 	var/oddities = rand(2,4)
 	var/list/stats = ALL_STATS
 	var/list/final_oddity = list()
@@ -162,10 +162,10 @@
 	..()
 
 /datum/perk/fate/rat
-	name = "Rat"
-	desc = "For all you know, taking what isn't yours is what you were best at. Be that roguery, theft or murder. It’s all the same no matter how you name it, after all. \
-			You start with a +10 to Mechanical stat and -10 to Vigilance. You will have a -10 to overall sanity health, meaning you will incur a breakdown faster than most. \
-			Additionally you have more quiet footsteps and a chance to not trigger traps on the ground."
+	name = "Rata"
+	desc = "Por todo lo que sabes, tomar lo que no es tuyo es lo que mejor se te da. Se ese picardo, robador o asesino. Es todo lo mismo no importa que nombre le pongas despues de todo. \
+			Empiezas  con +10 en la stat mecanica y -10 a tu vigilancia. Vas a tener -10 salud mental en general, significando que vas a tener un ataque nerviso mas rapido que los demas. \
+			Adicionalmente eres mas silencioso con tus pasos y tienes una chance de no activar trampas en el piso."
 	icon_state = "rat" //https://game-icons.net/
 
 /datum/perk/fate/rat/assign(mob/living/carbon/human/H)
@@ -179,10 +179,10 @@
 	..()
 
 /datum/perk/fate/rejected_genius
-	name = "Rejected Genius"
-	desc = "You see the world in different shapes and colors. \
-			Your sanity loss cap is removed, so stay clear of corpses or filth. You have less maximum sanity and no chance to have positive breakdowns. \
-			As tradeoff, you have 50% faster insight gain."
+	name = "Genio rechazado"
+	desc = "Ves el mundo en diferentes formas y colores. \
+			Tu cap de perdida de sanidad es removida, asi que mantende alejado de cuerpos o suciedad. Tienes una salud mental menor y no chance de ataques nerviosos positivos. \
+			A cambio, ganas conocimiento un 50 porciento mas rapido que los demas."
 	icon_state = "knowledge" //https://game-icons.net/
 
 /datum/perk/fate/rejected_genius/assign(mob/living/carbon/human/H)
@@ -202,11 +202,11 @@
 	..()
 
 /datum/perk/fate/oborin_syndrome
-	name = "Oborin Syndrome"
+	name = "Sindrome de oborin"
 	icon_state = "prism" //https://game-icons.net/1x1/delapouite/prism.html
-	desc = "A condition manifested at some recent point in human history. \
-			It’s origin and prevalence are unknown, but it is speculated to be a psyionic phenomenom.\
-			Your sanity pool is higher than that of others at the cost of the colors of the world."
+	desc = "Una condicion manifestada en algun punto de la historia humana. \
+			Su origen y prevalencia es desconocida, pero es especulado ser un fenomeno psionico.\
+			Tu salud mental es mayor a las de los demas al costo de los colores del mundo."
 
 /datum/perk/fate/oborin_syndrome/assign(mob/living/carbon/human/H)
 	..()
@@ -221,10 +221,10 @@
 	..()
 
 /datum/perk/fate/lowborn
-	name = "Lowborn"
+	name = "Clase Baja"
 	icon_state = "ladder" //https://game-icons.net/1x1/delapouite/hole-ladder.html
-	desc = "You are the bottom of society. The dirt and grime on the heel of a boot. You had one chance. You took it. \
-			You cannot be a person of authority. Additionally, you have the ability to have a name without a last name and have an increased sanity pool."
+	desc = "Vives al fondo de la sociedad. La suciedad y la mugre en el tacón de una bota. Tuviste una chance y la tomaste. \
+			No puedes ser una persona de autoridad. Adicionalmente, tienes la habilidad de tener un nombre sin un apellido ademas de tener una salud mental mayor."
 
 /datum/perk/fate/lowborn/assign(mob/living/carbon/human/H)
 	..()

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -1,7 +1,7 @@
 /datum/perk/survivor
-	name = "Survivor"
-	desc = "After seeing the death of many acquaintances and friends, witnessing death doesn't shock you as much as before. \
-			Halves sanity loss from seeing people die."
+	name = "Sobreviviente"
+	desc = "Despues de ver la muerte de muchos conocidos y amigos, presenciar muerte no te sorprende tanto como antes. \
+			Reduce a la mitad la perdida de cordura por ver personas morir."
 	icon_state = "survivor" // https://game-icons.net/1x1/lorc/one-eyed.html
 
 /datum/perk/survivor/assign(mob/living/carbon/human/H)
@@ -15,9 +15,9 @@
 	..()
 
 /datum/perk/job/artist
-	name = "Artist"
-	desc = "You have a lot of expertise in making works of art. You gain 150% insight from all sources but can only level \
-			up by creating works of art."
+	name = "Artista"
+	desc = "Tienes mucha experiencia al crear obras de arte. Ganas un 150% a tu ganancia de conocimiento de todas las fuentes pero solo puedes subir de nivel \
+			creado obras de arte."
 	var/old_max_insight = INFINITY
 	var/old_max_resting = INFINITY
 	var/old_insight_rest_gain_multiplier = 1
@@ -41,9 +41,9 @@
 
 
 /datum/perk/selfmedicated
-	name = "Medication Expertise"
-	desc = "Your carreer made you very intimate with different consumable substances. \
-			You total NSA is increased and chance to gain an addiction decreased."
+	name = "Experto en medicacion"
+	desc = "Tu carrera te a vuelto muy intimo con las diferentes sustancias quimicas. \
+			Tu NSA total es incrementada y la chance de ganar adicciones es disminuida."
 	icon_state = "selfmedicated" // https://game-icons.net/1x1/lorc/overdose.html
 
 /datum/perk/selfmedicated/assign(mob/living/carbon/human/H)
@@ -59,9 +59,9 @@
 	..()
 
 /datum/perk/vagabond
-	name = "Drifter"
-	desc = "You're used to see the worst sight the world has to offer. Your mind feels more resistant. \
-			This perk reduces the total sanity damage you can take from what is happening around you."
+	name = "Vagabundo	"
+	desc = "Estas acostumbrado a ver las peores cosas que el mundo puede ofrecer. Tu mente se siente resitente. \
+			Este perk reduce la cantidad total de daño de cordura que puedes tomar con lo que pasa alrededor tuyo."
 	icon_state = "vagabond" // https://game-icons.net/1x1/lorc/eye-shield.html
 
 /datum/perk/vagabond/assign(mob/living/carbon/human/H)
@@ -75,9 +75,9 @@
 	..()
 
 /datum/perk/merchant
-	name = "Merchant"
-	desc = "Money is what matters for you, and it's so powerful it lets you improve your skills. \
-			This perk lets you use money for leveling up. The credits need to be in your backpack."
+	name = "Comerciante"
+	desc = "Dinero es lo mas importante para ti y es tan poderoso como para mejorar tus habilidades. \
+			Este perk te deja usar dinero para subir de nivel. Los creditos tienen que estar en tu mochila."
 	icon_state = "merchant" // https://game-icons.net/1x1/lorc/cash.html and https://game-icons.net/1x1/delapouite/graduate-cap.html slapped on https://game-icons.net/1x1/lorc/trade.html
 
 /datum/perk/merchant/assign(mob/living/carbon/human/H)
@@ -97,9 +97,9 @@
 
 // ALERT: This perk has no removal method. Mostly because 3 out of 4 choices give knowledge to the player in the form of text, that would be pointless to remove.
 /datum/perk/deep_connection
-	name = "Deep connection"
-	desc = "With the help of your numerous trustworthy contacts, you manage to collect some useful information. \
-			Provides you with 1 of 4 boons: Language, Traitor Contract, a stash location or a special item in a box."
+	name = "Conexiones profundas	"
+	desc = "Con la ayuda de tus numerosos contactos fiables, puedes recolectar informacion util. \
+			Te proporciona 1 de 4 bendiciones: un lenguaje, un contrato de traidor, la localizacion de un alijo o una caja con un item especial adentro."
 	icon_state = "deepconnection" // https://game-icons.net/1x1/quoting/card-pickup.html
 
 /datum/perk/deep_connection/assign(mob/living/carbon/human/H)
@@ -127,18 +127,18 @@
 		if(CHOICE_LANG)
 			var/language = pick(valid_languages)
 			holder.add_language(language)
-			desc += " In particular, you happen to know [language]."
+			desc += "En particular, resulta que sabes hablar [language]."
 		if(CHOICE_TCONTRACT)
 			var/datum/antag_contract/A = pick(GLOB.various_antag_contracts)
-			desc += " You feel like you remembered something important."
-			holder.mind.store_memory("Thanks to your connections, you were tipped off about some suspicious individuals on the station. In particular, you were told that they have a contract: " + A.name + ": " + A.desc)
+			desc += "Sientes que recordaste algo importante."
+			holder.mind.store_memory("Gracias a tus conexiones, fuiste alertado acerca de unos indivudos sospechosos por la estacion. En particular, te dijeron que tenian contacto con:" + A.name + ": " + A.desc)
 		if(CHOICE_STASHPAPER)
-			desc += " You have a special note in your storage."
+			desc += "Tienens una nota especial contigo."
 			stash.spawn_stash()
 			var/obj/item/weapon/paper/stash_note = stash.spawn_note()
 			holder.equip_to_storage_or_drop(stash_note)
 		if(CHOICE_RAREOBJ)
-			desc += " You managed to smuggle a rare item aboard."
+			desc += "Lograste contrabandear un item raro a bordo."
 			var/obj/O = pickweight(RANDOM_RARE_ITEM - /obj/item/stash_spawner)
 			var/obj/item/weapon/storage/box/B = new
 			new O(B) // Spawn the random spawner in the box, so that the resulting random item will be within the box
@@ -150,8 +150,8 @@
 #undef CHOICE_RAREOBJ
 
 /datum/perk/sanityboost
-	name = "True Faith"
-	desc = "When near an obelisk, you feel your mind at ease. Your sanity regeneration is boosted."
+	name = "Fe verdadera"
+	desc = "Cuando estas cerca de un obelisco, tu mente se siente en paz. Tu regeneracion de cordura es mejorada."
 	icon_state = "sanityboost" // https://game-icons.net/1x1/lorc/templar-eye.html
 
 /datum/perk/sanityboost/assign(mob/living/carbon/human/H)
@@ -166,8 +166,8 @@
 
 /// Basically a marker perk. If the user has this perk, another will be given in certain conditions.
 /datum/perk/inspiration
-	name = "Exotic Inspiration"
-	desc = "Boosts your Cognition and Mechanical stats any time you imbibe any alcohol."
+	name = "Inspiracion exotica"
+	desc = "Obtienes un boost a tus stats de cognicion y mecanica cada vez que consumes alcohol."
 	icon_state = "inspiration" // https://game-icons.net/1x1/delapouite/booze.html
 
 /datum/perk/active_inspiration
@@ -187,15 +187,15 @@
 	..()
 
 /datum/perk/sommelier
-	name = "Sommelier"
-	desc = "You know how to handle even strongest alcohol in the universe."
+	name = "Sumiller"
+	desc = "Conoces como aguantar hasta el alcohol mas fuerte del universo."
 	icon_state = "inspiration"
 
 /datum/perk/neat
-	name = "Neat"
-	desc = "You're used to see blood and filth in all its forms. Your motto: a clean ship is the first step to enlightenment. \
-			This perk reduces the total sanity damage you can take from what is happening around you. \
-			You can regain sanity by cleaning."
+	name = "Pulcro"
+	desc = "Estas acostumbrado a ver sangre y suciedad en cualquier formas. Tu lema: una nave limpia es el primer paso hacia la iluminacion. \
+			Este perk reduce el daño total a tu sanidad que puedes tomar con lo que pasa alrededor tuyo \
+			Recuperas sanidad limpiando."
 	icon_state = "neat" // https://game-icons.net/1x1/delapouite/broom.html
 
 /datum/perk/neat/assign(mob/living/carbon/human/H)
@@ -209,9 +209,9 @@
 	..()
 
 /datum/perk/greenthumb
-	name = "Green Thumb"
-	desc = "After growing plants for years you have become a botanical expert. You can get all information about plants, from stats \
-	        to harvest reagents, by examining them. Gathering plants relaxes you and thus restores sanity."
+	name = "Dedo verde"
+	desc = "Despues de crecer plantas por años te has vuelto un botanico experto. Puedes ver toda la informacion de las plantas, desde stats \
+	        hasta quimicos en ellas, solo con examinarlas. Cosechar plantas te relaja y por ende recupera tu sanidad."
 	icon_state = "greenthumb" // https://game-icons.net/1x1/delapouite/farmer.html
 
 	var/obj/item/device/scanner/plant/virtual_scanner = new
@@ -221,8 +221,8 @@
 	virtual_scanner.is_virtual = TRUE
 
 /datum/perk/job/club
-	name = "Raising the bar"
-	desc = "You know how to mix drinks and change lives. People near you recover sanity."
+	name = "Elevando la barra"
+	desc = "Sabes como mezclar bebidas y cambiar vidas. Personas cerca tuyo recuperan sanidad."
 	icon_state = "inspiration"
 
 /datum/perk/job/club/assign(mob/living/carbon/human/H)

--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -1,52 +1,52 @@
 /datum/perk/oddity
-	gain_text = "You feel different. Exposure to oddities has changed you. Now you can't go back."
+	gain_text = "Te sientes diferente. La exposicion a las raresas te a cambiado. Ahora no puedes volver atras."
 
 /datum/perk/oddity/fast_walker
-	name = "Fast Walker"
-	desc = "Slow and steady wins the race. Prove them wrong. \
-			You move slightly faster."
+	name = "Caminador rapido"
+	desc = "Lento y firme gana la carrera. Demuestra que estan equivocados. \
+			Te mueves ligeramente mas rapido."
 	icon_state = "fast" // https://game-icons.net/1x1/delapouite/fast-forward-button.html
 
 /datum/perk/oddity/ear_of_quicksilver
-	name = "Ear of Silver"
-	desc = "Secrets do not escape your ears. Beware, loud noises are especially dangerous to you. \
-			You have further listening range, but flashbangs stun you for double the time."
+	name = "Oido de plata"
+	desc = "Los secretos no se le escapan a tus orejas. Cuidado, ruidos fuertes son especialmente peligrosos para ti. \
+			Tienes un campo de escucha mas grande, pero flashbangs te aturden el doble del tiempo."
 	icon_state = "ear" // https://game-icons.net
 
 /datum/perk/oddity/gunslinger
-	name = "Gunslinger"
-	desc = "Point, shoot, aim, shoot again. You are the fastest gun in space! \
-			You fire 33% faster with a one handed gun."
+	name = "Pistolero"
+	desc = "Apunta, dispara, apunta y dispara devuelta. Eres el pistolero mas rapido del espacio! \
+			Disparas armas de una mano un 33% mas rapido."
 	icon_state = "dual_shot" // https://game-icons.net/1x1/delapouite/bullet-impacts.html
 
 /datum/perk/oddity/terrible_fate
-	name = "Terrible Fate"
-	desc = "You realize the painful truth of death. You don't want to die and despise death - dying is a unmistakable horror to you. \
-			Anyone who is around you at the moment of your death must roll a Vigilance sanity check. If they fail, their sanity will instantly be dropped to 0."
+	name = "Destino terrible"
+	desc = "Te diste cuenta de la dolorosa verdad de la muerte. No quieres morir y odias la muerte - morir es un horror inconfundible para ti. \
+			Cualquier que este alrededor tuyo al momento de tu muerte va a tener que rodar un checkeo de vigilancia. Si lo fallan, su sanidad instantaneamente caera a 0."
 	icon_state = "murder" // https://game-icons.net/1x1/delapouite/chalk-outline-murder.html
 
 /datum/perk/oddity/unfinished_delivery
-	name = "Unfinished Delivery"
-	desc = "Even though destination is your death, you have not reached it yet. \
-			You have a 33% to get revived after death."
+	name = "Entrega inconclusa"
+	desc = "Aun que tu destino es muerte, aun no has llegado hay aun. \
+			Tienes una chance de 33% de ser revivido despues de morir."
 	icon_state = "regrowth" // https://game-icons.net/1x1/delapouite/stump-regrowth.html
 
 /datum/perk/oddity/lungs_of_iron
-	name = "Lungs of Iron"
-	desc = "Your lungs have improved volume. You could easily win a diving contest. \
-			You take only half breathing damage."
+	name = "Pulmones de hierro"
+	desc = "Tus pulmones incrementaron en volumen. Puedes facilmente ganar una competicion de buceo. \
+			Recibes solo la mitad de daño respiratorio."
 	icon_state = "lungs" // https://game-icons.net/1x1/lorc/one-eyed.html
 
 /datum/perk/oddity/blood_of_lead
-	name = "Blood of Lead"
-	desc = "Rotten food, disgusting garbage, poisons - all is less harmful to you now. \
-			You only take half toxin damage."
+	name = "Sangre de plomo"
+	desc = "Comida podrida, basura asquerosa, veneno - todo esto es menos dañino ahora. \
+			Recibes solo la mitad de daño de toxinas."
 	icon_state = "liver" // https://game-icons.net
 
 /datum/perk/oddity/space_asshole
 	name = "Space Asshole"
-	desc = "Holes, gravity, falling, tumbling. It's all the same. \
-			You take less damage from falling."
+	desc = "Huecos, gravedad, caer, tropezarse. Es todo lo mismo. \
+			Recibes menos daño por caida."
 	icon_state = "bomb" // https://game-icons.net
 
 /datum/perk/oddity/space_asshole/assign(mob/living/carbon/human/H)
@@ -63,7 +63,7 @@
 
 /datum/perk/oddity/parkour
 	name = "Parkour"
-	desc = "You can climb tables and ladders faster."
+	desc = "Puedes trapar mesas y escaleras mas rapido."
 	icon_state = "parkour" //https://game-icons.net/1x1/delapouite/jump-across.html
 
 /datum/perk/oddity/parkour/assign(mob/living/carbon/human/H)
@@ -77,9 +77,9 @@
 	..()
 
 /datum/perk/oddity/charming_personality
-	name = "Charming Personality"
-	desc = "A little wink and a confident smile goes far in this place. People are more comfortable with your company. \
-			They will recover sanity around you."
+	name = "Personalidad encantadora"
+	desc = "Un pequeño guiño y una sonrisa con confianza te puede llevar lejos en este lugar. Las personas son mas comodas en tu compania. \
+			Ellos recuperaran sanidad si estan cerca de ti."
 	icon_state = "flowers" // https://game-icons.net/1x1/lorc/flowers.html
 
 /datum/perk/oddity/charming_personality/assign(mob/living/carbon/human/H)
@@ -93,9 +93,9 @@
 	..()
 
 /datum/perk/oddity/horrible_deeds
-	name = "Horrible Deeds"
-	desc = "The itch. The blood. They see the truth in your actions and are horrified. \
-			People around you lose sanity."
+	name = "Acciones horribles"
+	desc = "La picazon. La sangre. Ellos ven la verdad de tus acciones y estan horrorizados. \
+			Personas cerca de ti perderan cordura."
 	icon_state = "bad_breath" // https://game-icons.net
 
 /datum/perk/oddity/horrible_deeds/assign(mob/living/carbon/human/H)
@@ -109,26 +109,26 @@
 	..()
 
 /datum/perk/oddity/chaingun_smoker
-	name = "Chaingun Smoker"
-	desc = "The cigarette is your way of life. It makes you feel less sick and tougher when you chomp down on cigars. \
-			You heal a slight amount by smoking and recover sanity more quickly."
+	name = "Fumador metralleta"
+	desc = "El cigarillo es tu forma de vida. te hace sentir menos enfermo y mas fuerte cuando masticas algunos cigarros. \
+			Te curas minimamente cuando fumas ademas de recuperar cordura mas rapidamente."
 	icon_state = "cigarette" // https://game-icons.net
 
 /datum/perk/oddity/nightcrawler
-	name = "Nightcrawler"
-	desc = "You are faster in the darkness."
+	name = "Rastreador de noche"
+	desc = "Eres mas rapido en la oscuridad."
 	icon_state = "night" // https://game-icons.net/1x1/lorc/night-sky.html
 
 /datum/perk/oddity/fast_fingers
-	name = "Fast Fingers"
-	desc = "Nothing is safe around your hands. You are a true kleptomaniac. \
-			Taking items off others is without sound and prompts, it's also quicker, and you can slip pills into drinks unnoticed."
+	name = "Dedos rapidos"
+	desc = "Nada esta seguro cerca de tus manos. Eres un verdadero cleptómaniatico. \
+			Puedes sacarle cosas a otros sin sonido o avisos, tambien es mas rapido y puedes pasar pastillas en bebidas sin que nadie se de cuenta."
 	icon_state = "robber_hand" // https://game-icons.net/1x1/darkzaitzev/robber-hand.html
 
 /datum/perk/oddity/quiet_as_mouse
-	name = "Quiet as a Mouse"
-	desc = "Being deadly, easy. Silent? Even easier now. \
-			You are 50% more quiet."
+	name = "Silenciosos como un raton"
+	desc = "Ser letal, facil. Silencioso? aun mas facil aun. \
+			Eres un 50% mas silencioso."
 	icon_state = "footsteps" // https://game-icons.net
 
 /datum/perk/oddity/quiet_as_mouse/assign(mob/living/carbon/human/H)
@@ -142,21 +142,21 @@
 	..()
 
 /datum/perk/oddity/balls_of_plasteel
-	name = "Balls of Plasteel"
-	desc = "Pain comes and goes. You have gotten used to it. \
-			Your paincrit tolerance is higher."
+	name = "Bolas de plastiacero"
+	desc = "Dolor viene y va. Te acostumbraste ya. \
+			Tu tolerancia de dolor critico es mayor."
 	icon_state = "golem" // https://game-icons.net
 
 /datum/perk/oddity/junkborn
-	name = "Junkborn"
-	desc = "One man's trash is a another man's comeup. \
-			You have a higher chance of finding a rare item in trash piles."
+	name = "Nacido en basura"
+	desc = "La basura de un hombre es el tesoro de otro. \
+			Tienes una chance mas alta de encontrar items raros en pilas de basura."
 	icon_state = "treasure" // https://game-icons.net
 
 /datum/perk/oddity/ass_of_concrete
-	name = "Ass of Concrete"
-	desc = "Years of training your body made you a hulk of a person. No more pushing around. \
-			Nobody can move past you, even on help intent. You wont slip in gravity."
+	name = "Culo de concreto"
+	desc = "Años de entrenar tu cuerpo te a convertido en una gran persona. No mas empujes. \
+			Nadie puede pasar por ti, nisiquiera en intencion de ayuda. No te resbalaras cuando no haya gravedad."
 	icon_state = "muscular" // https://game-icons.net
 
 /datum/perk/oddity/ass_of_concrete/assign(mob/living/carbon/human/H)
@@ -170,9 +170,9 @@
 	..()
 
 /datum/perk/oddity/toxic_revenger
-	name = "Toxic Revenger"
-	desc = "A heart of gold does not matter when blood is toxic. Those who breathe your air, share your fate. \
-			People around you receive toxin damage."
+	name = "vengador toxico"
+	desc = "Tu corazon de oro no importa cuando tu sangre es toxica. Aquellos que respiren tu aire, sufriran tu mismo destino. \
+			Personas alrededor tuyo reciben daño de toxinas."
 	icon_state = "Hazmat" // https://game-icons.net
 	var/cooldown = 1 MINUTES
 	var/initial_time
@@ -198,22 +198,22 @@
 				continue
 		L.reagents?.add_reagent("toxin", 5)
 		L.emote("cough")
-		to_chat(L, SPAN_WARNING("[holder] emits a strange smell."))
+		to_chat(L, SPAN_WARNING("[holder] Emite un olor extraño."))
 
 /datum/perk/oddity/absolute_grab
-	name = "Absolute Grab"
-	desc = "It pays to be a predator. You don't grab, You lunge. \
-			You can grab people 1 tile away. Does not work with objects in between you."
+	name = "Agarre absoluto"
+	desc = "A veces paga ser el depredador. Tu no agarras, tu embistes. \
+			Puedes agarrar personas que esten a un tile de distancia. No funciona si hay objetos entre ustedes."
 	icon_state = "grab" // https://game-icons.net
 
 /datum/perk/oddity/sure_step
-	name = "Sure Step"
-	desc = " You are more likely to avoid traps."
+	name = "Pisada segura"
+	desc = "Es mas probable que evadas trampas."
 	icon_state = "mantrap"
 
 /datum/perk/oddity/market_prof
-	name = "Market Professional"
-	desc = "Just by looking at the item you can know how much it cost."
+	name = "Profesional del mercado"
+	desc = "Solo examinando los items podes saber cuanto cuestan."
 	icon_state = "market_prof"
 
 ///////////////////////////////////////
@@ -221,11 +221,11 @@
 ///////////////////////////////////////
 
 /datum/perk/nt_oddity
-	gain_text = "God chose you to expand his will."
+	gain_text = "Dios te a elegigo para expandir su voluntad."
 
 /datum/perk/nt_oddity/holy_light
-	name = "Holy Light"
-	desc = "You have been touched by the divine. You now provide a weak healing aura, healing both brute and burn damage to any NeoThelogists nearby as well as yourself."
+	name = "Luz divina"
+	desc = "Has sido tocado por el poder divino. Emites una debil aura curadora, curando daño bruto y quemaduras a cualquier Neoteologista que este cerca de ti."
 	icon_state = "third_eye"  //https://game-icons.net/1x1/lorc/third-eye.html
 	var/healing_power = 0.1
 	var/cooldown = 1 SECONDS // Just to make sure that perk don't go berserk.

--- a/code/datums/setup_option/backgrounds/fate.dm
+++ b/code/datums/setup_option/backgrounds/fate.dm
@@ -1,14 +1,14 @@
 /datum/category_group/setup_option_category/background/fate
-	name = "Fate"
+	name = "Destino"
 	category_item_type = /datum/category_item/setup_option/background/fate
 
 /datum/category_item/setup_option/background/fate
 
 /datum/category_item/setup_option/background/fate/paper_worm
-	name = "Paper Worm"
-	desc = "You were a clerk and bureaucrat for all your life. Cramped offices with angry people is where your personality was forged. \
-			Coffee is your blood, your mind is corporate slogans, and personal life is nonexistent. \
-			But here you are, on a spaceship flying to hell. There is something more to you, something that may come to light later."
+	name = "Burocrático"
+	desc = "Siempre fuiste un oficinista y un burocrata toda tu vida. Oficinas apretadas con personas enojadas es donde tu personalidad se forjo. \
+			El café es tu sangre, tu mente son eslóganes corporativos y la vida personal es inexistente. \
+			Pero aquí estás, en una nave espacial volando hacia el infierno. Hay algo más para ti, algo que puede salir a la luz más tarde."
 
 	stat_modifiers = list(
 		STAT_ROB = -10,
@@ -21,59 +21,59 @@
 	perks = list(PERK_PAPER_WORM)
 
 /datum/category_item/setup_option/background/fate/freelancer
-	name = "Freelancer"
-	desc = "Whatever was your job, you never stayed in one place for too long or had lasting contracts. \
-			You were always on the move, looking for a brighter future on the other side. \
-			And because of that you never specialised as much as you should, but have broader array of other skills."
+	name = "Independiente"
+	desc = "Sea cual sea tu trabajo, nunca pudiste estar en un sitio demasiado tiempo ni tener contactos duraderos. \
+			Siempre estas en movimiento, buscando un futuro más brillante en el otro lado. \
+			Y porque nunca te especializaste tanto como deberías,ahora tienes una más amplia series de habilidades."
 
 	perks = list(PERK_FREELACER)
 
 /datum/category_item/setup_option/background/fate/nihilist
-	name = "Nihilist"
-	desc = "You simply ran out of fucks to give at some point in your life. \
-			Deciding to ignore the illusion of morals and justice, you realize there is only one thing of worth. You. \
-			Will you still be loyal only to yourself when the gates of hell open?"
+	name = "Nihilista"
+	desc = "En algun punto de tu vida te rendiste en que esta te importara. \
+			Decidiendo ignorar la ilusión de la moral y la justicia, te das cuenta de que sólo hay una cosa que vale la pena en esta vida. Tu mismo. \
+			¿Seguirás siendo leal sólo a ti mismo cuando se abran las puertas del infierno?"
 
 	perks = list(PERK_NIHILIST)
 
 /datum/category_item/setup_option/background/fate/moralist
-	name = "Moralist"
-	desc = "A day may come when the courage of men fails, when we forsake our friends and break all bonds of fellowship. \
-			But it is not this day. This day you fight! \
-			Carry this fire with you - light the way for others."
+	name = "Moralista"
+	desc = "Un dia llegara donde el coraje de los hombres caera, cuando abandonemos a nuestros amigos y rompamos todo los lazos de compañerismo. \
+			Pero este no es ese dia. Este sera el dia donde lucharas! \
+			Lleva este llama contigo y ilumina el camino de los demás."
 
 	perks = list(PERK_MORALIST)
 
 
 /datum/category_item/setup_option/background/fate/drug_addict
-	name = "Drug Addict"
-	desc = "For reasons you cannot remember, you decided to resort to major drug use. You have lost the battle, and now you suffer the consequences. \
-			Now it is all you that drives you forward. All you have left to fight the cruel reality, or escape from it for some time."
+	name = "Adicto a las drogas"
+	desc = "Por razones que no recuerdas, decidiste recurrir al consumo de drogas importantes. Pero has perdido la batalla, y ahora sufres las consecuencias. \
+			Ahora es todo lo que te impulsa a seguir adelante. Todo lo que te queda para luchar contra la cruel realidad, o para escapar de ella durante algún tiempo."
 
 	perks = list(PERK_DRUG_ADDICT)
 
 
 /datum/category_item/setup_option/background/fate/alcoholic
-	name = "Alcoholic"
-	desc = "You imagined the egress from all your trouble and pain at the bottom of the bottle, but the way only led to a labyrinth. \
-			You never stopped from coming back to it, trying again and again, poisoning your mind until you lost control. Now your face bears witness to your self-destruction. \
-			There is only one key to survival, and it is the liquid that has shown you the way down."
+	name = "Alcoholico"
+	desc = "Imaginaste la salida de todos tus problemas y dolores se encontraban al fondo de la botella, pero este camino sólo te condujo a un laberinto. \
+			Nunca dejaste de volver por mas, intentándolo una y otra vez, envenenando tu mente hasta que perdiste el control. Ahora tu cara es testigo de tu autodestrucción. \
+			Sólo hay una clave para sobrevivir, y es el líquido que te ha mostrado el camino hacia abajo."
 
 	stat_modifiers = list(STAT_COG = -10)
 	perks = list(PERK_ALCOHOLIC)
 
 /datum/category_item/setup_option/background/fate/noble
 	name = "Noble"
-	desc = "You are a descendant of a long-lasting family, being part of a lineage of high status that can be traced back to the early civilization of your domain. \
-			What legacy will you build? \
-			Start with an heirloom weapon, higher chance to be on traitor contracts and removed sanity cap. Stay clear of filth and danger."
+	desc = "Eres descendiente de una familia longeva, formando parte de un linaje de alto estatus que se remonta a las primeras civilizaciónes de tu dominio. \
+			¿Qué legado construirás? \
+			Empiezas con un arma reliquia, mayor chance de ser marcado como objetivo de traidores y tu cap de perdida de sanidad es removida. Mantente alejado del peligro y la suciedad."
 			
 	perks = list(PERK_NOBLE)
 
 /datum/category_item/setup_option/background/fate/rat
-	name = "Rat"
-	desc = "For all you know, taking what isn't yours is what you were best at. Be that roguery, theft or murder. It’s all the same no matter how you name it, after all. \
-			You know the ways of infiltration, salvaging and getting away unharmed and with heavier pockets."
+	name = "Rata"
+	desc = "Por todo lo que sabes, tomar lo que no es tuyo es lo que mejor se te da. Se ese picardo, robador o asesino. Es todo lo mismo no importa que nombre le pongas despues de todo. \
+			Conoces las formas de infiltración, de salvamento y de salir ileso con los bolsillos más llenos."
 
 	perks = list(PERK_RAT)
 	stat_modifiers = list(
@@ -82,28 +82,28 @@
 	)
 
 /datum/category_item/setup_option/background/fate/rejected_genius
-	name = "Rejected Genius"
-	desc = "You see the world in different shapes and colors. \
-			You know that the truth is out there, that you only need that one last push to uncover the terrible truth beyond.\
-			So you pressed on, never stopping the pursuit of knowledge, to absorb all life and death had to offer. \
-			Finally this expedition will reveal the secrets of the universe. Or break you forever."
+	name = "Genio rechazado"
+	desc = "Ves el mundo en diferentes formas y colores. \
+			Sabes que la verdad está ahí fuera, que sólo necesitas ese último empujón para descubrir la terrible verdad más allá.\
+			Así que seguiste empujando, sin dejar de buscar el conocimiento, para absorber todo lo que la vida y la muerte tenían que ofrecer. \
+			Finalmente esta expedición revelará los secretos del universo. O te romperá para siempre."
 
 	perks = list(PERK_REJECTED_GENIUS)
 
 /datum/category_item/setup_option/background/fate/oborin_syndrome
-	name = "Oborin Syndrome"
-	desc = "A condition manifested at some recent point in human history. \
-			It’s origin and prevalence are unknown, but it is speculated to be a psyionic phenomenom.\
-			You are affected by this so called Oborin Syndrome and are unable to see the colors of the world. You see what lies beyond them."
+	name = "Sindrome de oborin"
+	desc = "Una condición manifestada en algún momento reciente de la historia de la humanidad. \
+			Se desconoce su origen y prevalencia, pero se especula que es un fenómeno psiónico.\
+			Estás afectado por el llamado Síndrome de Oborin y eres incapaz de ver los colores del mundo. Ves lo que hay más allá de ellos."
 
 	perks = list(PERK_OBORIN_SYNDROME)
 
 /datum/category_item/setup_option/background/fate/lowborn
-	name = "Lowborn"
-	desc = "You are the bottom of society. The dirt and grime on the heel of a boot. You had one chance. You took it. \
-			You never knew your parents and were lucky enough to learn how to read, and that, in time, landed you a position on this ship. \
-			Would you still choose to be part of this journey if you knew what it meant? Will you leave a mark or be forgotten forever? \
-			You cannot play command roles. Additionally, you have the ability to have a name without a last name and have an increased sanity pool."
+	name = "Clase Baja"
+	desc = "Eres el fondo de la sociedad. La suciedad y la mugre en el tacón de una bota. Tuviste una oportunidad y la tomaste. \
+			Nunca conociste a tus padres y tuviste la suerte de aprender a leer, y eso, con el tiempo, te consiguió un puesto en esta nave. \
+			¿Seguirías eligiendo formar parte de este viaje si supieras lo que significa? ¿Dejarás huella o serás olvidado para siempre? \
+			No puedes jugar roles de comando. Tienes la posibilidad de tener un nombre sin apellido y tienes una cantidad de cordura aumentada."
 
 	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/chaplain, /datum/job/merchant, /datum/job/cmo, /datum/job/rd, /datum/job/ihc)
 	restricted_depts = IRONHAMMER | MEDICAL | SCIENCE

--- a/code/datums/setup_option/backgrounds/origin.dm
+++ b/code/datums/setup_option/backgrounds/origin.dm
@@ -1,15 +1,15 @@
 //As a general rule, all origin backrounds must have summ of +5 of stat values
 
 /datum/category_group/setup_option_category/background/origin
-	name = "Origin"
+	name = "Origen"
 	category_item_type = /datum/category_item/setup_option/background/origin
 
 /datum/category_item/setup_option/background/origin
 
 /datum/category_item/setup_option/background/origin/oberth
-	name = "Mercenary"
-	desc = "You're a soldier by trade, whether with a PMC or actual government. Close-quarters combat isn't unfamiliar to you, but you're more used to having your hands around a rifle. \
-			Even if that rifle is more of a shotgun."
+	name = "Mercenario"
+	desc = "Eres un soldado de profesión, ya sea con una PMC o con el gobierno actual. El combate cuerpo a cuerpo no te es desconocido, pero estás más acostumbrado a tener las manos alrededor de un rifle. \
+			Incluso si ese rifle es más bien una escopeta."
 
 	stat_modifiers = list(
 		STAT_ROB = 5,
@@ -26,10 +26,10 @@
 
 
 /datum/category_item/setup_option/background/origin/predstraza
-	name = "Thug"
-	desc = "You're an unsavory sort, aren't you? \
-			Maybe you're a criminal, maybe you just got into a lot of fights. Either way, you know how to swing your weight around and how to not get caught off-guard. \
-			...All those blows to your head may have knocked a few things loose, though..."
+	name = "Maton"
+	desc = "Eres un tipo desagradable, ¿no? \
+			Quizá seas un delincuente, o quizá te hayas metido en muchas peleas. En cualquier caso, sabes cómo mover tu peso y cómo no ser agarrado con la guardia baja. \
+			...Aunque...todos esos golpes a la cabeza pueden haber dejado algunas cosas flojas hay adentro..."
 
 	stat_modifiers = list(
 		STAT_ROB = 8,
@@ -42,8 +42,8 @@
 
 
 /datum/category_item/setup_option/background/origin/sich_prime
-	name = "Vagrant"
-	desc = "Miscreant. You're used to having to do what it takes to survive, patching up your own wounds to survive, and being... familiar, with how to get through locks."
+	name = "Vagabundo"
+	desc = "Estás acostumbrado a tener que hacer lo que sea necesario para sobrevivir, a remendar tus propias heridas para sobrevivir, y ser... familiar, con la forma de pasar por cerraduras."
 
 	stat_modifiers = list(
 		STAT_ROB = 5,
@@ -56,9 +56,9 @@
 
 
 /datum/category_item/setup_option/background/origin/new_rome
-	name = "Assistant"
-	desc = "You've generally spent the majority of your life as the second note to more important people. \
-			In your time, you've caught a few tricks. Jack-of-all-trades, master of none."
+	name = "Asistente"
+	desc = "Generalmente has pasado la mayor parte de tu vida como la segunda nota de gente más importante. \
+			En su tiempo, ha cogido unos cuantos trucos. El que todo lo sabe pero el maestro de nada."
 
 	stat_modifiers = list(
 		STAT_ROB = 2,
@@ -71,10 +71,10 @@
 
 
 /datum/category_item/setup_option/background/origin/shimatengoku
-	name = "Academic"
-	desc = "You're more familiar with studying and practicing your trade than with how to kill a roach the size of a horse.\
-			As a compensation, you're at least probably earning more than your peers...probably. \
-			More specialized for work planet-side than on a ship barely held together by tape and prayer, you'll have to be extra-cautious to avoid unfortunate accidents..."
+	name = "Academico"
+	desc = "Estás más familiarizado con el estudio y la práctica de tu oficio que con la forma de matar una cucaracha del tamaño de un caballo.\
+			Como compensación, al menos es probable que ganes más que tus compañeros... probablemente. \
+			Más especializado en el trabajo en el planeta que en una nave que apenas se mantiene unida con cinta adhesiva y rezos, tendrá que ser muy precavido para evitar desafortunados accidentes..."
 
 	stat_modifiers = list(
 		STAT_ROB = -8,
@@ -87,9 +87,9 @@
 
 
 /datum/category_item/setup_option/background/origin/hmss_destined
-	name = "Crewman"
-	desc = "You're not unfamiliar with working on spaceships. Maybe you've been working for NanoTrasen for some time, or maybe you used to be part of some navy.\
-			 Either way, you know the general ins-and-outs of working on a ship."
+	name = "Tripulante"
+	desc = "No eres familiar con trabajar en naves espaciales. Tal vez lleves algún tiempo trabajando para NanoTrasen, o tal vez hayas formado parte de alguna armada.\
+			 En cualquier caso, conoces los detalles generales de trabajar en una nave."
 
 	stat_modifiers = list(
 		STAT_ROB = 7,
@@ -102,8 +102,8 @@
 
 
 /datum/category_item/setup_option/background/origin/crozet
-	name = "Colonist"
-	desc = "You're used to working a planet-side job, whether it's ranching, ship repairs, or good ol' ore-extraction. This fancy-shmancy spaceship stuff's a far cry from what you're used to, but it pays good."
+	name = "Colonista"
+	desc = "Estás acostumbrado a trabajar en el planeta, ya sea en la ganadería, en la reparación de naves o en la extracción de minerales. Este trabajo en una nave espacial de lujo está muy lejos de lo que estás acostumbrado, pero paga bien."
 
 	stat_modifiers = list(
 		STAT_ROB = 6,
@@ -116,9 +116,9 @@
 
 
 /datum/category_item/setup_option/background/origin/first_expeditionary_fleet
-	name = "Activist"
-	desc = "You have a strong set of beliefs, and stick to them. You're not afraid to clash with authority when push comes to shove. \
-			Maybe you're even on the NEV Northern Light because you're running from the law. Either way, you're still carrying out your campaign for justice."
+	name = "Activista"
+	desc = "Tienes un conjunto de creencias fuertes y te atienes a ellas. No tienes miedo de chocar con la autoridad cuando se trata de empujar. \
+			Tal vez incluso estés en la NEV Northern Light porque estás huyendo de la ley. De cualquier manera, sigues llevando a cabo tu campaña de justicia."
 
 	stat_modifiers = list(
 		STAT_ROB = 5,
@@ -131,8 +131,8 @@
 
 
 /datum/category_item/setup_option/background/origin/end_point
-	name = "Greasemonkey"
-	desc = "To put it bluntly, you're good with machines. Real good. Maybe you specialize in engines, or electrician work, but you know your way around a workshop."
+	name = "Mecanico"
+	desc = "Para decirlo sin vueltas, eres bueno con las máquinas. Muy bueno. Tal vez te especialices en motores, o en trabajos de electricista, pero sabes moverte por un taller."
 
 	stat_modifiers = list(
 		STAT_ROB = -3,
@@ -145,10 +145,10 @@
 
 
 /datum/category_item/setup_option/background/origin/nss_forecaster
-	name = "Nomad"
-	desc = "You used to roam the stars. Maybe you still do. Why would you miss your home when your home is all around you? There's so much to see, and you are ready for all of it! \
-			Your lack of settling down means that you don't have intimate knowledge of any particular subject, but you've always been able to get around that with your general knowledge and wit.\
-			So far, at least."
+	name = "Nomada"
+	desc = "Solías vagar por las estrellas. Tal vez todavía lo haces. ¿Por qué ibas a echar de menos tu casa cuando tu hogar está a tu alrededor? Hay tanto que ver, ¡y tú estás preparado para todo! \
+			Tu falta de asentamiento hace que no tengas un conocimiento profundo de ningún tema en particular, pero siempre has podido solucionar eso con tus conocimientos generales y tu ingenio.\
+			Hasta el momento, por lo menos	."
 
 	stat_modifiers = list(
 		STAT_ROB = 2,
@@ -162,10 +162,10 @@
 
 /datum/category_item/setup_option/background/origin/eureka
     name = "Eureka"
-    desc = "Once a paradise for the Australian colonists that lived on it, their neutrality during the corporate wars cost them this paradise. \
-            And thus did the Syndicate and Nanotrasen both bomb Eureka to hell, causing once verdant lands to become hellish deserts of nuclear proportions. \
-            As a side effect of this once the corporate wars ended, Eurekans are known to be eerily good trackers and pathfinders in these conditions and elsewhere, causing what's left of the Eurekan people to pay a tithe to Hansa and Neotheology both in the form of criminals. \
-            All in the name of saving what's left."
+    desc = "Una vez fue un paraíso para los colonos australianos que vivían en él, su neutralidad durante las guerras corporativas les costó este paraíso. \
+            Y así, el Sindicato y Nanotrasen bombardearon Eureka hasta el infierno, provocando que las tierras antes verdes se convirtieran en desiertos infernales de proporciones nucleares. \
+            Como efecto secundario de esto, una vez que las guerras corporativas terminaron, los eurekanos son conocidos por ser extrañamente buenos rastreadores y exploradores en estas condiciones y en otros lugares, haciendo que lo que queda del pueblo eurekano paguen tributo a la Hansa y a la Neoteología ambos en forma de criminales. \
+            Todo en nombre de salvar lo que queda."
 
     stat_modifiers = list(
         STAT_ROB = -5,

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -1,17 +1,17 @@
 
 var/list/dreams = list(
-	"an ID card","a bottle","a familiar face","a crewmember","a toolbox","an Aegis operative","the captain",
-	"voices from all around","deep space","a doctor","the engine","a traitor","an ally","darkness",
-	"light","a scientist","a monkey","a catastrophe","a loved one","a gun","warmth","freezing","the sun",
-	"a hat","the Luna","a ruined station","a planet","phoron","air","the medical bay","the bridge","blinking lights",
-	"a blue light","an abandoned laboratory","NanoTrasen","mercenaries","blood","healing","power","respect",
-	"riches","space","a crash","happiness","pride","a fall","water","flames","ice","melons","flying","the eggs","money",
-	"the Head of Personnel","the Aegis Commander","the Chief Engineer","a Chief Science Officer","a Chief Medical Officer",
-	"the inspector","the gunnery sergeant","a member of the internal affairs","a ship engineer","the janitor","atmospheric technician",
-	"the union merchant","a union technician","the botanist","a union miner","the psychologist","the chemist","the geneticist",
-	"the virologist","the roboticist","the chef","the bartender","the preacher","the librarian","a mouse",
-	"a beach","the holodeck","a smokey room","a voice","the cold","a mouse","an operating table","the bar","the rain",
-	"the ai core","the mining station","the research station","a beaker of strange liquid",
+	"una tarjeta de identificacion","una botella","una cara familiar","un tripulante","una caja de herramientas","un operativo Aegis ","el capitan",
+	"voces por todas partes","el espacio profundo","un doctor","el motor","un traidor","un aliado","oscuridad",
+	"luz","un cientifico","un mono","una catastrofe","un ser querido","un arma","calor","frio","el sol",
+	"un sombrero","la Luna","una estacion arruinada","un planeta","phoron","aire","la via medica","el puente","luces parpadeantes",
+	"una luz azul","un laboratorio abandonado","NanoTrasen","mercenarios","sangre","curacion","poder","respeto",
+	"ricos","espacio","un choque","felicidad","orgullo","una caida","agua","llamas","hielo","melones","volar","los huevos","dinero",
+	"el cabeza de personal","el comandante de Aegis ","el jefe ingeniero","el directora de ciencias","el director medico",
+	"el inspector","el sargento de artilleria","un miembro de asuntos internos","un ingeniero","el concerje","el tecnico atmosferico",
+	"el mercader de la union","un tecnico de la union","el botanico","el minero de la union","el psicologo","el quimico","el genetico",
+	"el virologo","el robotico","el chef","el camarero","el clerigo","el bibliotecario","un raton",
+	"una playa","el holodeck","una habitacion humeante","una voz","el frio...","odio","una mesa de operaciones","el bar","la lluvia",
+	"el core de la AI","la estacion minera","la estacion cientifica","un vaso con un liquido extraño","amor"
 	)
 
 mob/living/carbon/proc/dream()

--- a/code/modules/mob/living/carbon/human/chem_side_effects.dm
+++ b/code/modules/mob/living/carbon/human/chem_side_effects.dm
@@ -84,16 +84,16 @@
 	name = "Headache"
 	triggers = list("cryoxadone" = 10, "bicaridine" = 15, "tricordrazine" = 15)
 	cures = list("alkysine", "tramadol", "paracetamol", "oxycodone")
-	cure_message = "Your head stops throbbing..."
+	cure_message = "Tu cabeza deja de palpitar..."
 
 /datum/medical_effect/headache/on_life(mob/living/carbon/human/H, strength)
 	switch(strength)
 		if(1 to 10)
-			H.custom_pain("You feel a light pain in your head.",0)
+			H.custom_pain("Sientes un ligero dolor de cabeza.",0)
 		if(11 to 30)
-			H.custom_pain("You feel a throbbing pain in your head!",1)
+			H.custom_pain("Sientes que la cabeza te palpita con dolor!",1)
 		if(31 to INFINITY)
-			H.custom_pain("You feel an excrutiating pain in your head!",1)
+			H.custom_pain("Sientes un dolor de cabeza excruciante!",1)
 
 // BAD STOMACH
 // ===========
@@ -101,16 +101,16 @@
 	name = "Bad Stomach"
 	triggers = list("kelotane" = 30, "dermaline" = 15)
 	cures = list("anti_toxin")
-	cure_message = "Your stomach feels a little better now..."
+	cure_message = "Tu estomago se siente un poco mejor ahora..." 
 
 /datum/medical_effect/bad_stomach/on_life(mob/living/carbon/human/H, strength)
 	switch(strength)
 		if(1 to 10)
-			H.custom_pain("You feel a bit light around the stomach.",0)
+			H.custom_pain("Sientes un pequeño dolor en el estomago.",0) 
 		if(11 to 30)
-			H.custom_pain("Your stomach hurts.",0)
+			H.custom_pain("Tu estomago duele.",0) 
 		if(31 to INFINITY)
-			H.custom_pain("You feel sick.",1)
+			H.custom_pain("Te sientes nauseado.",1) 
 
 // CRAMPS
 // ======
@@ -118,17 +118,17 @@
 	name = "Cramps"
 	triggers = list("anti_toxin" = 30, "tramadol" = 15)
 	cures = list("inaprovaline")
-	cure_message = "The cramps let up..."
+	cure_message = "El calambre parece estar terminando..." 
 
 /datum/medical_effect/cramps/on_life(mob/living/carbon/human/H, strength)
 	switch(strength)
 		if(1 to 10)
-			H.custom_pain("The muscles in your body hurt a little.",0)
+			H.custom_pain("Los musculos en tu cuerpo duelen un poco.",0) 
 		if(11 to 30)
-			H.custom_pain("The muscles in your body cramp up painfully.",0)
+			H.custom_pain("Los musculos de tu cuerpo se acalambran dolorosamente.",0)  
 		if(31 to INFINITY)
-			H.emote("me",1,"flinches as all the muscles in their body cramp up.")
-			H.custom_pain("There's pain all over your body.",1)
+			H.emote("me",1,"Se estremese al sentir todos los musculos de su cuerpo acalambrarse.") 
+			H.custom_pain("Sientes dolor en cada parte de tu cuerpo.",1) 
 
 // ITCH
 // ====
@@ -136,14 +136,14 @@
 	name = "Itch"
 	triggers = list("space_drugs" = 10)
 	cures = list("inaprovaline")
-	cure_message = "The itching stops..."
+	cure_message = "La picazon paro..." 
 
 /datum/medical_effect/itch/on_life(mob/living/carbon/human/H, strength)
 	switch(strength)
 		if(1 to 10)
-			H.custom_pain("You feel a slight itch.",0)
+			H.custom_pain("Sientes una ligera picazon.",0) 
 		if(11 to 30)
-			H.custom_pain("You want to scratch your itch badly.",0)
+			H.custom_pain("Queres rascarte esa picazon desesperadamente.",0) 
 		if(31 to INFINITY)
-			H.emote("me",1,"shivers slightly.")
-			H.custom_pain("This itch makes it really hard to concentrate.",1)
+			H.emote("me",1,"Tiembla ligeramente.") 
+			H.custom_pain("Esta picazon esta haciendo muy dificil concentrarse.",1) 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -24,15 +24,15 @@
 	switch(act)
 		if ("airguitar")
 			if (!src.restrained())
-				message = "is strumming the air and headbanging like a safari chimp."
+				message = "empieza a tocar una guitara imaginaria y a sacudir la cabeza como un mono en un safari."
 				m_type = 1
 
 		if ("blink")
-			message = "blinks."
+			message = "pestañea."
 			m_type = 1
 
 		if ("blink_r")
-			message = "blinks rapidly."
+			message = "pestañea rapidamente."
 			m_type = 1
 
 		if ("bow")
@@ -47,9 +47,9 @@
 					param = null
 
 				if (param)
-					message = "bows to [param]."
+					message = "hace una reverencia hacia [param]."
 				else
-					message = "bows."
+					message = "hace una reverencia."
 			m_type = 1
 
 		if ("custom")
@@ -88,10 +88,10 @@
 		if("pain")
 			if(!message)
 				if(miming)
-					message = "appears to be in pain!"
+					message = "parece estar en dolor!"
 					m_type = 1 // Can't we get defines for these?
 				else
-					message = "twists in pain."
+					message = "se retuerse del dolor."
 					m_type = 1
 
 			cloud_emote = "cloud-pain"
@@ -108,73 +108,73 @@
 					param = null
 
 				if (param)
-					message = "salutes to [param]."
+					message = "saluda a [param]."
 				else
-					message = "salutes."
+					message = "saluda."
 			m_type = 1
 
 		if ("choke")
 			if(miming)
-				message = "clutches [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] throat desperately!"
+				message = "agarra su garganta desesperadamente!"
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "chokes!"
+					message = "se ahoga!"
 					m_type = 2
 				else
-					message = "makes a strong noise."
+					message = "hace un ruido fuerte."
 					m_type = 2
 
 		if ("clap")
 			if (!src.restrained())
-				message = "claps."
+				message = "aplaude."
 				m_type = 2
 				if(miming)
 					m_type = 1
 		if ("flap")
 			if (!src.restrained())
-				message = "flaps [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] wings."
+				message = "agita sus alas."
 				m_type = 2
 				if(miming)
 					m_type = 1
 
 		if ("aflap")
 			if (!src.restrained())
-				message = "flaps [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] wings ANGRILY!"
+				message = "agita sus alas AGRESIVAMENTE!"
 				m_type = 2
 				if(miming)
 					m_type = 1
 
 		if ("drool")
-			message = "drools."
+			message = "babea."
 			m_type = 1
 
 		if ("eyebrow")
-			message = "raises an eyebrow."
+			message = "levanta una ceja."
 			m_type = 1
 
 		if ("chuckle")
 			if(miming)
-				message = "appears to chuckle."
+				message = "hace una carcajada silenciosa."
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "chuckles."
+					message = "suelta una risa."
 					m_type = 2
 				else
-					message = "makes a noise."
+					message = "hace un sonido."
 					m_type = 2
 
 		if ("twitch")
-			message = "twitches violently."
+			message = "tiembla violentamente."
 			m_type = 1
 
 		if ("twitch_s")
-			message = "twitches."
+			message = "tiembla ligeramente."
 			m_type = 1
 
 		if ("faint")
-			message = "faints."
+			message = "se desmaya."
 			if(src.sleeping)
 				return //Can't faint while asleep
 			src.sleeping += 10 //Short-short nap
@@ -182,62 +182,62 @@
 
 		if ("cough")
 			if(miming)
-				message = "appears to cough!"
+				message = "parece toser!"
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "coughs!"
+					message = "tose!"
 					m_type = 2
 				else
-					message = "makes a strong noise."
+					message = "hace un ruido fuerte."
 					m_type = 2
 
 		if ("frown")
-			message = "frowns."
+			message = "frunce el seño."
 			m_type = 1
 
 		if ("nod")
-			message = "nods."
+			message = "asiente."
 			m_type = 1
 
 		if ("blush")
-			message = "blushes."
+			message = "se sonroja."
 			m_type = 1
 
 		if ("wave")
-			message = "waves."
+			message = "agita su mano en el aire."
 			m_type = 1
 
 		if ("gasp")
 			if(miming)
-				message = "appears to be gasping!"
+				message = "parece estar jadeando por aire!"
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "gasps!"
+					message = "jadea!"
 					m_type = 2
 				else
-					message = "makes a weak noise."
+					message = "hace un sonido debil."
 					m_type = 2
 			cloud_emote = "cloud-gasp"
 
 		if ("deathgasp")
 			if(stats.getPerk(PERK_TERRIBLE_FATE))
-				message = "their inert body emits a strange sensation and a cold invades your body. Their screams before dying recount in your mind."
-			else
+				message = "su cuerpo emite una extraña sensacion y de repente un frio invade tu cuerpo. el sonido de sus gritos antes de morir solo hacen eco en tu mente."  
+			else           
 				message = "[species.death_message]"
 			m_type = 1
 
 		if ("giggle")
 			if(miming)
-				message = "giggles silently!"
+				message = "hace una risita silenciosa!"
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "giggles."
+					message = "hace una risita."
 					m_type = 2
 				else
-					message = "makes a noise."
+					message = "hace un sonido."
 					m_type = 2
 
 		if ("glare")
@@ -251,9 +251,9 @@
 				param = null
 
 			if (param)
-				message = "glares at [param]."
+				message = "mira firmemente a [param]."
 			else
-				message = "glares."
+				message = "mira firmemente."
 
 		if ("stare")
 			var/M = null
@@ -266,9 +266,9 @@
 				param = null
 
 			if (param)
-				message = "stares at [param]."
+				message = "observa a [param]."
 			else
-				message = "stares."
+				message = "observa."
 
 		if ("look")
 			var/M = null
@@ -282,86 +282,86 @@
 				param = null
 
 			if (param)
-				message = "looks at [param]."
+				message = "mira a [param]."
 			else
-				message = "looks."
+				message = "mira."
 			m_type = 1
 
 		if ("grin")
-			message = "grins."
+			message = "sonrie un poco."
 			m_type = 1
 
 		if ("cry")
 			if(miming)
-				message = "cries."
+				message = "llora en silencio."
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "cries."
+					message = "llora."
 					m_type = 2
 				else
-					message = "makes a weak noise. [get_visible_gender() == MALE ? "He" : get_visible_gender() == FEMALE ? "She" : "They"] [get_visible_gender() == NEUTER ? "frown" : "frowns"]."
+					message = "hace un sonido debil. [get_visible_gender() == MALE ? "el" : get_visible_gender() == FEMALE ? "ella" : "ellos"] [get_visible_gender() == NEUTER ? "frunce el seño" : "frunce el seño" ]."
 					m_type = 2
 
 		if ("sigh")
 			if(miming)
-				message = "sighs."
+				message = "parece suspirar."
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "sighs."
+					message = "suspira."
 					m_type = 2
 				else
-					message = "makes a weak noise."
+					message = "hace un sonido debil."
 					m_type = 2
 
 		if ("laugh")
 			if(miming)
-				message = "acts out a laugh."
+				message = "mimica reirse."
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "laughs."
+					message = "rie."
 					m_type = 2
 				else
-					message = "makes a noise."
+					message = "hace un sonido."
 					m_type = 2
 
 		if ("mumble")
-			message = "mumbles!"
+			message = "balbucea algo!"
 			m_type = 2
 			if(miming)
 				m_type = 1
 
 		if ("grumble")
 			if(miming)
-				message = "grumbles!"
+				message = "gruñe!"
 				m_type = 1
 			if (!muzzled)
-				message = "grumbles!"
+				message = "gruñe!"
 				m_type = 2
 			else
-				message = "makes a noise."
+				message = "hace un sonido."
 				m_type = 2
 
 		if ("groan")
 			if(miming)
-				message = "appears to groan!"
+				message = "parece quejarse!"
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "groans!"
+					message = "suelta un quejido!"
 					m_type = 2
 				else
-					message = "makes a loud noise."
+					message = "hace un sonido fuerte."
 					m_type = 2
 
 		if ("moan")
 			if(miming)
-				message = "appears to moan!"
+				message = "parece gemir!"
 				m_type = 1
 			else
-				message = "moans!"
+				message = "gime!"
 				m_type = 2
 
 		if ("johnny")
@@ -372,10 +372,10 @@
 				param = null
 			else
 				if(miming)
-					message = "takes a drag from a cigarette and blows \"[M]\" out in smoke."
+					message = "se saca el cigarillo de su boca y exhala \"[M]\" el humo." 
 					m_type = 1
 				else
-					message = "says, \"[M], please. He had a family.\" [src.name] takes a drag from a cigarette and blows his name out in smoke."
+					message = "dice, \"[M], por favor. El tenia una familia.\" [src.name] toma el cigarro de su boca y exhala el humo en su nombre."  
 					m_type = 2
 
 		if ("point")
@@ -388,26 +388,26 @@
 							break
 
 				if (!M)
-					message = "points."
+					message = "apunta."
 				else
 					pointed(M)
 
 				if (M)
-					message = "points to [M]."
+					message = "apunta a [M]."
 				else
 			m_type = 1
 
 		if ("raise")
 			if (!src.restrained())
-				message = "raises a hand."
+				message = "levanta la mano."
 			m_type = 1
 
 		if("shake")
-			message = "shakes [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] head."
+			message = "sacude su cabeza."
 			m_type = 1
 
 		if ("shrug")
-			message = "shrugs."
+			message = "se encoge de hombros."
 			m_type = 1
 
 		if ("signal")
@@ -415,85 +415,84 @@
 				var/t1 = round(text2num(param))
 				if (isnum(t1))
 					if (t1 <= 5 && (!src.r_hand || !src.l_hand))
-						message = "raises [t1] finger\s."
+						message = "levanta [t1] dedo\s."
 					else if (t1 <= 10 && (!src.r_hand && !src.l_hand))
-						message = "raises [t1] finger\s."
+						message = "levanta [t1] dedo\s."
 			m_type = 1
 
 		if ("smile")
-			message = "smiles."
+			message = "sonrie."
 			m_type = 1
 
 		if ("shiver")
-			message = "shivers."
+			message = "tiembla."
 			m_type = 2
 			if(miming)
 				m_type = 1
 
 		if ("pale")
-			message = "goes pale for a second."
+			message = "se ve [get_visible_gender() == MALE ? "palido" : "palida"] por un momento."
 			m_type = 1
 
 		if ("tremble")
-			message = "trembles in fear!"
+			message = "tiembla en miedo!"
 			m_type = 1
 
 		if ("sneeze")
 			if (miming)
-				message = "sneezes."
+				message = "estornuda sin hacer ruido."
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "sneezes."
+					message = "estornuda."
 					m_type = 2
 				else
-					message = "makes a strange noise."
 					m_type = 2
 
 		if ("sniff")
-			message = "sniffs."
+			message = "olfatea." // quizas cambie este no estoy muy feliz con como esta
 			m_type = 2
 			if(miming)
 				m_type = 1
 
 		if ("snore")
 			if (miming)
-				message = "sleeps soundly."
+				message = "duerme profundamente."
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "snores."
+					message = "ronca."
 					m_type = 2
 				else
-					message = "makes a noise."
+					message = "hace un sonido."
 					m_type = 2
 
 		if ("whimper")
 			if (miming)
-				message = "appears hurt."
+				message = "parece estar [get_visible_gender() == MALE ? "herido" : "herida"]."
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "whimpers."
+					message = "lloriquea."
 					m_type = 2
 				else
-					message = "makes a weak noise."
+					message = "hace un sonido debil."
 					m_type = 2
 
 		if ("wink")
-			message = "winks."
+			message = "guiña."
 			m_type = 1
 
 		if ("yawn")
 			if (!muzzled)
-				message = "yawns."
+				message = "bosteza."
 				m_type = 2
 				if(miming)
 					m_type = 1
 
 		if ("collapse")
 			Paralyse(2)
-			message = "collapses!"
+			message = "colapsa!"
 			m_type = 2
 			if(miming)
 				m_type = 1
@@ -511,9 +510,9 @@
 					M = null
 
 				if (M)
-					message = "hugs [M]."
+					message = "abraza [M]."
 				else
-					message = "hugs [get_visible_gender() == MALE ? "himself" : get_visible_gender() == FEMALE ? "herself" : "themselves"]."
+					message = "se abraza a [get_visible_gender() == MALE ? "si mismo" : "si misma" ]."
 
 		if ("handshake")
 			m_type = 1
@@ -529,9 +528,9 @@
 
 				if (M)
 					if (M.canmove && !M.r_hand && !M.restrained())
-						message = "shakes hands with [M]."
+						message = "le da un apreton de manos a [M]."
 					else
-						message = "holds out [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] hand to [M]."
+						message = "presenta su mano a [M]."
 
 		if("dap")
 			m_type = 1
@@ -543,20 +542,20 @@
 							M = A
 							break
 				if (M)
-					message = "gives daps to [M]."
+					message = "le da un saludo espacial a [M]."
 				else
-					message = "sadly can't find anybody to give daps to, and daps [get_visible_gender() == MALE ? "himself" : get_visible_gender() == FEMALE ? "herself" : "themselves"]. Shameful."
-
+					message = "tristemente no pudiste encontrar a nadie con quien hacer el saludo espacial asi que te saludas a ti [get_visible_gender() == MALE ? "mismo" : "misma"]. Que vergonzoso."
+                            
 		if ("scream")
 			if (miming)
-				message = "acts out a scream!"
+				message = "actua un grito silencioso!"
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "screams!"
+					message = "grita!"
 					m_type = 2
 				else
-					message = "makes a very loud noise."
+					message = "hace un ruido muy fuerte."
 					m_type = 2
 			cloud_emote = "cloud-scream"
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -40,7 +40,7 @@
 	var/race_key = 0       	                             // Used for mob icon cache string.
 	var/icon/icon_template                               // Used for mob icon generation for non-32x32 species.
 	var/mob_size	= MOB_MEDIUM
-	var/show_ssd = "fast asleep"
+	var/show_ssd = "Durmiendo profundamente"
 	var/virus_immune
 	var/blood_volume = 560                               // Initial blood volume.
 	var/hunger_factor = DEFAULT_HUNGER_FACTOR            // Multiplier for hunger.
@@ -85,7 +85,7 @@
 	var/dusted_anim = "dust-h"
 	var/death_sound
 	var/death_message = "Deja de luchar y cae flacido, sus ojos ahora muertos y sin vida..."
-	var/knockout_message = "cae inconsciente por el golpe!" 
+	var/knockout_message = "cae inconsciente del golpe!" 
 	var/halloss_message = "Cae al suelo, muy debil como para continuar luchando."
 	var/halloss_message_self = "Sientes demasiado dolor como para seguir..."
 
@@ -279,15 +279,15 @@
 
 /datum/species/proc/hug(mob/living/carbon/human/H,var/mob/living/target)
 
-	var/t_him = "them"
+	var/t_him = "hacerlo"
 	switch(target.gender)
 		if(MALE)
-			t_him = "him"
+			t_him = "hacerlo"
 		if(FEMALE)
-			t_him = "her"
+			t_him = "hacerla"
 
-	H.visible_message(SPAN_NOTICE("[H] hugs [target] to make [t_him] feel better!"), \
-					SPAN_NOTICE("You hug [target] to make [t_him] feel better!"))
+	H.visible_message(SPAN_NOTICE("[H] abraza a [target] para [t_him] sentir mejor!"), \
+					SPAN_NOTICE("abrazas a [target] para [t_him] sentir mejor!"))
 
 /datum/species/proc/remove_inherent_verbs(var/mob/living/carbon/human/H)
 	if(inherent_verbs)
@@ -445,10 +445,10 @@
 
 /datum/species/proc/get_description(var/header, var/append, var/verbose = TRUE, var/skip_detail, var/skip_photo)
 	var/list/damage_types = list(
-		"physical trauma" = brute_mod,
-		"burns" = burn_mod,
-		"lack of air" = oxy_mod,
-		"poison" = toxins_mod
+		"Trauma fisico" = brute_mod,
+		"Quemaduras" = burn_mod,
+		"Falta de aire" = oxy_mod,
+		"Veneno" = toxins_mod
 	)
 	if(!header)
 		header = "<center><h2>[name]</h2></center><hr/>"
@@ -472,40 +472,40 @@
 		if(!skip_detail)
 			dat += "<small>"
 			if(spawn_flags & SPECIES_CAN_JOIN)
-				dat += "</br><b>Often present among humans.</b>"
+				dat += "</br><b>Usualmente presente entre humanos.</b>"
 			if(spawn_flags & SPECIES_IS_WHITELISTED)
-				dat += "</br><b>Whitelist restricted.</b>"
+				dat += "</br><b>Restringido por whitelist.</b>"
 			if(!has_process[OP_HEART])
-				dat += "</br><b>Does not have blood.</b>"
+				dat += "</br><b>No posee sangre.</b>"
 		/*	if(!has_organ[breathing_organ])
 				dat += "</br><b>Does not breathe.</b>"*/
 			if(species_flags & SPECIES_FLAG_NO_SCAN)
-				dat += "</br><b>Does not have DNA.</b>"
+				dat += "</br><b>No tiene DNA.</b>"
 			if(species_flags & SPECIES_FLAG_NO_PAIN)
-				dat += "</br><b>Does not feel pain.</b>"
+				dat += "</br><b>No siente dolor.</b>"
 			if(species_flags & SPECIES_FLAG_NO_MINOR_CUT)
-				dat += "</br><b>Has thick skin/scales.</b>"
+				dat += "</br><b>Tiene piel/escalas gruesas.</b>"
 			if(species_flags & SPECIES_FLAG_NO_SLIP)
-				dat += "</br><b>Has excellent traction.</b>"
+				dat += "</br><b>Tiene excelente traccion.</b>"
 			if(species_flags & SPECIES_FLAG_NO_POISON)
-				dat += "</br><b>Immune to most poisons.</b>"
+				dat += "</br><b>Inmune a la mayoria de venenos.</b>"
 			if(appearance_flags & HAS_A_SKIN_TONE)
-				dat += "</br><b>Has a variety of skin tones.</b>"
+				dat += "</br><b>Tiene una variedad de tonos de piel.</b>"
 			if(appearance_flags & HAS_SKIN_COLOR)
-				dat += "</br><b>Has a variety of skin colours.</b>"
+				dat += "</br><b>Tiene una variedad de colores de piel.</b>"
 			if(appearance_flags & HAS_EYE_COLOR)
-				dat += "</br><b>Has a variety of eye colours.</b>"
+				dat += "</br><b>Tiene una variedad de colores de ojos.</b>"
 			if(species_flags & SPECIES_FLAG_IS_PLANT)
-				dat += "</br><b>Has a plantlike physiology.</b>"
+				dat += "</br><b>Tienen una fisiologia vegetal.</b>"
 			if(slowdown)
-				dat += "</br><b>Moves [slowdown > 0 ? "slower" : "faster"] than most.</b>"
+				dat += "</br><b>Se mueven mas [slowdown > 0 ? "lento" : "rapido"] que la mayoria.</b>"
 			for(var/kind in damage_types)
 				if(damage_types[kind] > 1)
-					dat += "</br><b>Vulnerable to [kind].</b>"
+					dat += "</br><b>Son vulnerables contra [kind].</b>"
 				else if(damage_types[kind] < 1)
-					dat += "</br><b>Resistant to [kind].</b>"
-			dat += "</br><b>They breathe [gas_data.name[breath_type]].</b>"
-			dat += "</br><b>They exhale [gas_data.name[exhale_type]].</b>"
+					dat += "</br><b>Son resistente contra [kind].</b>"
+			dat += "</br><b>Ellos respiran [gas_data.name[breath_type]].</b>"
+			dat += "</br><b>Ellos exhalan [gas_data.name[exhale_type]].</b>"
 		/*	if(LAZYLEN(poison_types))
 				dat += "</br><b>[capitalize(english_list(poison_types))] [LAZYLEN(poison_types) == 1 ? "is" : "are"] poisonous to them.</b>"*/
 			dat += "</small>"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -84,10 +84,10 @@
 	var/gibbed_anim = "gibbed-h"
 	var/dusted_anim = "dust-h"
 	var/death_sound
-	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."
-	var/knockout_message = "has been knocked unconscious!"
-	var/halloss_message = "slumps to the ground, too weak to continue fighting."
-	var/halloss_message_self = "You're in too much pain to keep going..."
+	var/death_message = "Deja de luchar y cae flacido, sus ojos ahora muertos y sin vida..."
+	var/knockout_message = "cae inconsciente por el golpe!" 
+	var/halloss_message = "Cae al suelo, muy debil como para continuar luchando."
+	var/halloss_message_self = "Sientes demasiado dolor como para seguir..."
 
 	// Environment tolerance/life processes vars.
 	var/reagent_tag                                   //Used for metabolizing reagents.
@@ -113,14 +113,14 @@
 	var/heat_discomfort_level = 315                   // Aesthetic messages about feeling warm.
 	var/cold_discomfort_level = 285                   // Aesthetic messages about feeling chilly.
 	var/list/heat_discomfort_strings = list(
-		"You feel sweat drip down your neck.",
-		"You feel uncomfortably warm.",
-		"Your skin prickles in the heat."
+		"Sientes sudor bajar por tu cuello.",
+		"Te sientes incomodamente caliente.",
+		"Tu piel empieza a picar bajo el calor."
 		)
 	var/list/cold_discomfort_strings = list(
-		"You feel chilly.",
-		"You shiver suddenly.",
-		"Your chilly flesh stands out in goosebumps."
+		"Te sientes frio.",
+		"Empiezas a temblar.",
+		"El frio te pone los pelos de punta."
 		)
 
 	// HUD data vars.

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/roach
 	name = "Kampfer Roach"
-	desc = "A monstrous, dog-sized cockroach. These huge mutants can be everywhere where humans are, on ships, planets and stations."
+	desc = "Una monstruosa cucaracha del tamaño de un perro. Estos enormes mutantes pueden estar en cualquier lugar donde haya humanos, en naves, planetas y estaciones."
 
 	icon_state = "roach"
 
@@ -9,7 +9,7 @@
 	density = FALSE //Swarming roaches! They also more robust that way.
 
 	attack_sound = 'sound/voice/insect_battle_bite.ogg'
-	emote_see = list("chirps loudly.", "cleans its whiskers with forelegs.")
+	emote_see = list("chirría fuertemente.", "se limpia los bigotes con las patas delanteras.")
 	turns_per_move = 4
 	turns_since_move = 0
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/roach/bluespace
 	name = "Unbekannt Roach"
-	desc = "This shimmering insectoid-like creature greatly resembles a giant cockroach. It flickers in and out of reality, as if it didn't really belong here."
+	desc = "Esta criatura brillante de aspecto insectoide se parece mucho a una cucaracha gigante. Entra y sale de la realidad, como si no perteneciera a ella.."
 	icon_state = "bluespaceroach"
 	maxHealth = 25
 	health = 25

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/fuhrer.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/fuhrer.dm
@@ -1,7 +1,7 @@
 //Fuhrer roach is a colossal, slow moving leader
 /mob/living/carbon/superior_animal/roach/fuhrer
 	name = "Fuhrer Roach"
-	desc = "A glorious leader of cockroaches. Literally Hitler."
+	desc = "Un glorioso líder de cucarachas. Literalmente Hitler."
 	icon_state = "fuhrer"
 
 	turns_per_move = 4
@@ -69,7 +69,7 @@ reinforcements left it will attempt to evacuate*/
 				playsound(src.loc, 'sound/voice/shriek1.ogg', 100, 1, 8, 8)
 				//Playing the sound twice will make it sound really horrible
 
-			visible_message(SPAN_DANGER("[src] emits a horrifying wail as nearby burrows stir to life!"))
+			visible_message(SPAN_DANGER("[src] emite un horrible chillido y las madrigueras cercanas empiezan a cobran vida!"))
 
 			//Add all nearby burrows to the distressed burrows list
 			//for (var/obj/structure/burrow/B in range(20, loc))
@@ -87,7 +87,7 @@ reinforcements left it will attempt to evacuate*/
 				playsound(src.loc, 'sound/voice/hiss6.ogg', 100, 1, 8, 8)
 				//Playing the sound twice will make it sound really horrible
 
-			visible_message(SPAN_DANGER("[src] emits a haunting scream as it turns to flee, taking the nearby horde with it...."))
+			visible_message(SPAN_DANGER("[src] emite un grito estremecedor mientras se da la vuelta para huir, llevándose consigo a la horda cercana...."))
 			for (var/obj/structure/burrow/B in find_nearby_burrows())
 				B.evacuate()
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/hunter.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/roach/hunter
 	name = "Jager Roach"
-	desc = "A monstrous, dog-sized cockroach. This one has bigger claws."
+	desc = "Una monstruosa cucaracha del tamaño de un perro. Esta tiene garras más grandes."
 	icon_state = "jager"
 
 	turns_per_move = 3

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
@@ -5,7 +5,7 @@ Has ability of every roach.
 
 /mob/living/carbon/superior_animal/roach/kaiser
 	name = "Kaiser Roach"
-	desc = "A glorious emperor of roaches."
+	desc = "Un glorioso emperador de cucarachas."
 	icon = 'icons/mob/64x64.dmi'
 	icon_state = "kaiser_roach"
 	icon_living = "kaiser_roach"
@@ -73,7 +73,7 @@ Has ability of every roach.
 			var/damage = rand(melee_damage_lower, melee_damage_upper)
 			L.damage_through_armor(damage, TOX)
 			playsound(src, 'sound/voice/insect_battle_screeching.ogg', 30, 1, -3)
-			L.visible_message(SPAN_DANGER("\the [src] globs up some toxic bile all over \the [L]!"))
+			L.visible_message(SPAN_DANGER("\the [src] se derrama un poco de bilis tóxica por todas partes \the [L]!"))
 
 // SUPPORT ABILITIES
 /mob/living/carbon/superior_animal/roach/kaiser/proc/gas_attack()
@@ -85,7 +85,7 @@ Has ability of every roach.
 
 	S.attach(location)
 	S.set_up(gas_sac, gas_sac.total_volume, 0, location)
-	src.visible_message(SPAN_DANGER("\the [src] secretes strange vapors!"))
+	src.visible_message(SPAN_DANGER("\the [src] segrega vapores extraños!"))
 
 	spawn(0)
 		S.start()
@@ -96,7 +96,7 @@ Has ability of every roach.
 /mob/living/carbon/superior_animal/roach/support/findTarget()
 	. = ..()
 	if(. && gas_attack())
-		visible_emote("charges at [.] in clouds of poison!")
+		visible_emote("carga hacia [.] en nubes de veneno!")
 
 // FUHRER ABILITIES
 /mob/living/carbon/superior_animal/roach/kaiser/proc/distress_call()
@@ -112,7 +112,7 @@ Has ability of every roach.
 		playsound(src.loc, 'sound/voice/shriek1.ogg', 100, 1, 8, 8)
 		spawn(2)
 			playsound(src.loc, 'sound/voice/shriek1.ogg', 100, 1, 8, 8)
-		visible_message(SPAN_DANGER("[src] emits a horrifying wail as nearby burrows stir to life!"))
+		visible_message(SPAN_DANGER("[src] emite un horrible chillido y las madrigueras cercanas empiezan a cobran vida!"))
 		for (var/obj/structure/burrow/B in find_nearby_burrows(src))
 			B.distress(TRUE)
 
@@ -135,27 +135,27 @@ Has ability of every roach.
 		return FALSE
 	if(prob(40))
 		// TODO: Make Kaiser bite user's arm off here.
-		visible_message("[src] hesitates for a moment... and then charges at [user]!")
+		visible_message("[src] duda por un momento... y luego carga contra [user]!")
 		return FALSE //Sometimes roach just be like that
 	//fruits and veggies are not there own type, they are all the grown type and contain certain reagents. This is why it didnt work before
 	if(isnull(thefood.seed.chems["singulo"]))
 		return FALSE
-	visible_message("[src] scuttles towards [user], examining the [thefood] they have in their hand.")
+	visible_message("[src] se acerca a [user], examinando la [thefood] que tiene la mano.")
 	can_buckle = TRUE
 	if(do_after(src, taming_window, src)) //Here's your window to climb onto it.
 		if(!buckled_mob || user != buckled_mob) //They need to be riding us
 			can_buckle = FALSE
-			visible_message("[src] snaps out of its trance and rushes at [user]!")
+			visible_message("[src] rompe de su trance y se lanza hacia [user]!")
 			return FALSE
-		visible_message("[src] bucks around wildly, trying to shake [user] off!") //YEEEHAW
+		visible_message("[src] se agita violentamente, tratando de sacudir a [user] de encima!") //YEEEHAW
 		if(prob(60))
-			visible_message("[src] thrashes around and, throws [user] clean off!")
+			visible_message("[src] se agita y, lanza a [user] de su espalda!")
 			user.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
 			unbuckle_mob()
 			can_buckle = FALSE
 			return FALSE
 		friends += user
-		visible_message("[src] reluctantly stops thrashing around...")
+		visible_message("[src] cansada deja de quejarse...")
 		return TRUE
-	visible_message("[src] snaps out of its trance and rushes at [user]!")
+	visible_message("[src] rompe de su trance y se lanza hacia [user]!")
 	return FALSE

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/nanites.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/roach/nanite
 	name = "Kraftwerk Roach"
-	desc = "A deformed mess of a roach that is covered in metallic outcrops and formations. It seems to have a production center on its thorax."
+	desc = "Un desastre deformado de cucaracha que está cubierto de brotes y formaciones metálicas. Parece tener un centro de producción en su tórax."
 	icon_state = "naniteroach"
 
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/roachmeat/kraftwerk
@@ -51,8 +51,8 @@
 
 
 /mob/living/simple_animal/hostile/naniteswarm
-	name = "nanite infested miniroach cluster"
-	desc = "A swarm of disgusting locusts infested with nanomachines."
+	name = "grupo de minicucarachas infestadas de nanites"
+	desc = "Un enjambre de asquerosas criaturas plagadas de nanomáquinas."
 	icon = 'icons/mob/critter.dmi'
 	icon_state = "naniteroach"
 	icon_living = "naniteroach"

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/nitro.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/nitro.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/roach/nitro
 	name = "Benzin Roach"
-	desc = "A monstrous, dog-sized cockroach. This one smells like welding fuel."
+	desc = "Una monstruosa cucaracha del tamaño de un perro. Esta huele a combustible."
 	icon_state = "nitroroach"
 	turns_per_move = 6
 	maxHealth = 5

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/roachling.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/roachling.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/roach/roachling
 	name = "Roachling"
-	desc = "A tiny cockroach. It never stays still for long."
+	desc = "Una pequeña cucaracha. Nunca se queda quieta por mucho tiempo."
 	icon_state = "roachling"
 
 	turns_per_move = 3

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/support.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/support.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/roach/support
 	name = "Seuche Roach"
-	desc = "A monstrous, dog-sized cockroach. This one smells like hell and secretes strange vapors."
+	desc = "Una monstruosa cucaracha del tamaño de un perro. Esta huele como el infierno y segrega vapores extraños."
 	icon_state = "seuche"
 	turns_per_move = 6
 	maxHealth = 20
@@ -24,7 +24,7 @@
 
 	S.attach(location)
 	S.set_up(gas_sac, gas_sac.total_volume, 0, location)
-	src.visible_message(SPAN_DANGER("\the [src] secretes strange vapors!"))
+	src.visible_message(SPAN_DANGER("\the [src] segrega vapores extraños!"))
 
 	spawn(0)
 		S.start()
@@ -51,4 +51,4 @@
 /mob/living/carbon/superior_animal/roach/support/findTarget()
 	. = ..()
 	if(. && gas_attack())
-		visible_emote("charges at [.] in clouds of poison!")
+		visible_emote("carga hacia [.] en nubes de veneno!")

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/tank.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/tank.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/roach/tank
 	name = "Panzer Roach"
-	desc = "A monstrous, dog-sized cockroach. This one looks more robust than others."
+	desc = "Una monstruosa cucaracha del tamaño de un perro. Esta parece más robusta que otras."
 	icon_state = "panzer"
 	meat_amount = 4
 	turns_per_move = 2

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/toxic.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/toxic.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/roach/toxic
 	name = "Gestrahlte Roach"
-	desc = "A hulking beast of green, congealed waste. It has an enlarged salivatory gland for lobbing projectiles."
+	desc = "Una bestia enorme de desechos verdes y congelados. Tiene una glándula salival agrandada para lanzar proyectiles."
 	icon_state = "radioactiveroach"
 
 	meat_amount = 3
@@ -22,4 +22,4 @@
 			var/damage = rand(melee_damage_lower, melee_damage_upper)
 			L.damage_through_armor(damage, TOX)
 			playsound(src, 'sound/voice/insect_battle_screeching.ogg', 30, 1, -3)
-			L.visible_message(SPAN_DANGER("\the [src] globs up some toxic bile all over \the [L]!"))
+			L.visible_message(SPAN_DANGER("\the [src] se derrama un poco de bilis tóxica por todas partes \the [L]!"))


### PR DESCRIPTION

## Acerca del pull request

Esto traer todas las traducciones de emotes de humanos exclusivamente, mensajes de sueño, mensajes de efectos secundario de la medicina y mensajes generales 

## Por que es bueno para el juego

para que no se vea raro en un server español que usemos emotes en ingles ya que se ve raro durante conversacion  ademas de varias cosas generales que se ven frecuentemente como los sueños y por ejemplo mensajes de knockout ahora estarian en español tambien

## Changelog
:cl:
add: traducciones a los emotes, sueños, mensajes comunes y efectos de quimicos

del: varias cosas repetidas y varias diferenciaciones de hombre y mujer que no se aplicaban a nuestro idioma

tweak: cambie varias diferenciaciones para que sean aplicadas a otras palabras que si las necesitaban ademas de agregar 2 textos mas a los sueños que son "amor" y "odio" por que me parecia que faltaba esas cosas simples

/:cl:
